### PR TITLE
fix(sepa): transliterate party names and remittance info to EPC217-08 SEPA charset

### DIFF
--- a/lib/sepa-charset.ts
+++ b/lib/sepa-charset.ts
@@ -1,0 +1,125 @@
+/**
+ * SEPA character set sanitization.
+ *
+ * The EPC217-08 SEPA basic character set allows only:
+ *   a-z  A-Z  0-9  space  / - ? : ( ) . , ' +
+ *
+ * German banks (and most European banks) reject or mangle SEPA files that
+ * contain characters outside this set. This module provides a transliteration
+ * function so that common extended Latin characters (umlauts, accented letters)
+ * are mapped to their closest SEPA-safe equivalents before the XML is emitted.
+ */
+
+const SEPA_ALLOWED = /^[a-zA-Z0-9 /\-?:().,'+]*$/;
+
+/**
+ * Transliteration table for extended Latin characters to the EPC217-08 SEPA basic character set.
+ *
+ * German umlauts follow the ae/oe/ue convention (e.g. Ö -> Oe, ä -> ae).
+ * All other accented Latin letters map to their unaccented base letter.
+ * Characters with no mapping are silently dropped.
+ */
+const TRANSLITERATION_MAP: Record<string, string> = {
+  // German umlauts and sharp-s
+  ä: 'ae',
+  ö: 'oe',
+  ü: 'ue',
+  Ä: 'Ae',
+  Ö: 'Oe',
+  Ü: 'Ue',
+  ß: 'ss',
+  // Accented A
+  à: 'a',
+  á: 'a',
+  â: 'a',
+  ã: 'a',
+  å: 'a',
+  À: 'A',
+  Á: 'A',
+  Â: 'A',
+  Ã: 'A',
+  Å: 'A',
+  // AE ligature
+  æ: 'ae',
+  Æ: 'AE',
+  // C-cedilla
+  ç: 'c',
+  Ç: 'C',
+  // Accented E
+  è: 'e',
+  é: 'e',
+  ê: 'e',
+  ë: 'e',
+  È: 'E',
+  É: 'E',
+  Ê: 'E',
+  Ë: 'E',
+  // Accented I
+  ì: 'i',
+  í: 'i',
+  î: 'i',
+  ï: 'i',
+  Ì: 'I',
+  Í: 'I',
+  Î: 'I',
+  Ï: 'I',
+  // Eth
+  ð: 'd',
+  Ð: 'D',
+  // N-tilde
+  ñ: 'n',
+  Ñ: 'N',
+  // Accented O
+  ò: 'o',
+  ó: 'o',
+  ô: 'o',
+  õ: 'o',
+  ø: 'o',
+  Ò: 'O',
+  Ó: 'O',
+  Ô: 'O',
+  Õ: 'O',
+  Ø: 'O',
+  // Accented U
+  ù: 'u',
+  ú: 'u',
+  û: 'u',
+  Ù: 'U',
+  Ú: 'U',
+  Û: 'U',
+  // Accented Y
+  ý: 'y',
+  ÿ: 'y',
+  Ý: 'Y',
+  // Thorn
+  þ: 'th',
+  Þ: 'TH',
+};
+
+/**
+ * Sanitize a string to the EPC217-08 SEPA basic character set.
+ *
+ * Transliterates known extended Latin characters (umlauts, accented letters)
+ * to their closest SEPA-safe equivalents. Any remaining characters outside the
+ * allowed set are silently dropped. Multiple consecutive spaces are collapsed
+ * and leading/trailing spaces are trimmed.
+ *
+ * Use this function on all party names and remittance information before
+ * passing them to the SEPA XML writer.
+ */
+export function sanitizeSepa(value: string): string {
+  let result = '';
+  for (const ch of value) {
+    if (SEPA_ALLOWED.test(ch)) {
+      result += ch;
+    } else {
+      const mapped = TRANSLITERATION_MAP[ch];
+      if (mapped !== undefined) {
+        result += mapped;
+      }
+      // else: character has no SEPA equivalent, drop it silently
+    }
+  }
+  // Collapse multiple spaces and trim
+  return result.replace(/ {2,}/g, ' ').trim();
+}

--- a/lib/sepa-generation.test.ts
+++ b/lib/sepa-generation.test.ts
@@ -3,9 +3,36 @@
  */
 import { validateCreditorID, validateIBAN } from 'sepa';
 import { generateSepaXml } from './sepa-generation';
+import { sanitizeSepa } from './sepa-charset';
 import { CompensationDto } from '@/lib/dto';
 import xpath from 'xpath';
 import { describe, expect, test, vi } from 'vitest';
+
+// EPC217-08 allowed characters: a-z A-Z 0-9 space / - ? : ( ) . , ' +
+const SEPA_CHARSET = /^[a-zA-Z0-9 /\-?:().,'+]*$/;
+
+describe('sanitizeSepa', () => {
+  test('transliterates German umlauts and sharp-s', () => {
+    expect(sanitizeSepa('Jörg Müller-Schröße')).toBe('Joerg Mueller-Schroesse');
+  });
+
+  test('transliterates uppercase umlauts', () => {
+    expect(sanitizeSepa('Ärger mit Öl und Über')).toBe('Aerger mit Oel und Ueber');
+  });
+
+  test('passes through already-valid SEPA characters unchanged', () => {
+    expect(sanitizeSepa('SC Janus e.V.')).toBe('SC Janus e.V.');
+  });
+
+  test('drops characters with no SEPA equivalent', () => {
+    // emoji and other non-Latin chars have no mapping and are dropped
+    expect(sanitizeSepa('Test☃Name')).toBe('TestName');
+  });
+
+  test('collapses multiple spaces and trims', () => {
+    expect(sanitizeSepa('  Hello   World  ')).toBe('Hello World');
+  });
+});
 
 describe('Test sepa library', () => {
   test('CID validation', () => {
@@ -108,5 +135,51 @@ describe('sepa generation works', () => {
     expect(creditorIbans).toHaveLength(2);
     expect(creditorIbans[0]).toBe('DE11500105171658347596');
     expect(creditorIbans[1]).toBe('DE78500105172112588369');
+  });
+
+  test('transliterates umlaut names to the EPC217-08 SEPA charset in generated XML', () => {
+    // GIVEN: a trainer with a German umlaut name and a course with umlaut characters
+    const c: CompensationDto = {
+      user: {
+        id: '7',
+        name: 'Jörg Müller-Schröße',
+      },
+      iban: 'DE11500105171658347596',
+      correspondingIds: [10],
+      periodStart: '2024-01-01',
+      periodEnd: '2024-01-31',
+      totalCompensationCents: 7500,
+      totalTrainings: 3,
+      costCenterId: 1,
+      costCenterName: 'Kostenstelle 1',
+      courseName: 'Kräftigungsübungen',
+    };
+    // WHEN
+    const sepaXml = generateSepaXml([c]);
+    // THEN: the Nm element must contain only EPC217-08 allowed characters
+    const sepaDom = new DOMParser().parseFromString(sepaXml, 'text/xml');
+    const select = xpath.useNamespaces({
+      pain: 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.09',
+    });
+    const creditorNames = select(
+      `${TRANSACTIONS}/pain:Cdtr/pain:Nm/text()`,
+      sepaDom,
+      false,
+    ) as any as Node[];
+    expect(creditorNames).toHaveLength(1);
+    const name = creditorNames[0].textContent ?? '';
+    // Must not contain any character outside the EPC217-08 basic character set
+    expect(name).toMatch(SEPA_CHARSET);
+    expect(name).toBe('Joerg Mueller-Schroesse');
+    // remittance info must also be transliterated
+    const remittanceNodes = select(
+      `${TRANSACTIONS}/pain:RmtInf/pain:Ustrd/text()`,
+      sepaDom,
+      false,
+    ) as any as Node[];
+    expect(remittanceNodes).toHaveLength(1);
+    const remittance = remittanceNodes[0].textContent ?? '';
+    expect(remittance).toMatch(SEPA_CHARSET);
+    expect(remittance).toBe('Kraeftigungsuebungen 2024-01-01..2024-01-31');
   });
 });

--- a/lib/sepa-generation.ts
+++ b/lib/sepa-generation.ts
@@ -1,6 +1,7 @@
 import md5 from 'md5';
 import * as sepa from 'sepa';
 import { CompensationDto } from './dto';
+import { sanitizeSepa } from './sepa-charset';
 
 // There are two different formats for the sepa xml files.
 // This is the one used for transfers
@@ -26,7 +27,7 @@ export function generateSepaXml(compensations: CompensationDto[]): string {
   info.collectionDate = new Date();
   info.debtorIBAN = 'DE36370400440222411100';
   info.debtorBIC = 'COBADEFFXXX';
-  info.debtorName = 'SC Janus e.V.';
+  info.debtorName = sanitizeSepa('SC Janus e.V.');
   info.debtorId = 'DE2600100000045188';
   info.batchBooking = false;
   // we request the execution for today
@@ -35,10 +36,10 @@ export function generateSepaXml(compensations: CompensationDto[]): string {
 
   compensations.forEach((c) => {
     const tx = info.createTransaction();
-    tx.creditorName = c.user.name;
+    tx.creditorName = sanitizeSepa(c.user.name);
     tx.creditorIBAN = c.iban;
     tx.amount = c.totalCompensationCents / 100;
-    tx.remittanceInfo = `${c.courseName} ${c.periodStart}..${c.periodEnd}`;
+    tx.remittanceInfo = sanitizeSepa(`${c.courseName} ${c.periodStart}..${c.periodEnd}`);
     tx.end2endId = compensationHash(c);
     // FIXME: remove line after patch. This is not needed.
     tx.mandateSignatureDate = new Date();


### PR DESCRIPTION
## Problem

Trainer and course names are passed directly to sepa.js, which does not
transliterate extended Latin characters. The EPC217-08 SEPA basic character
set allows only: `a-z A-Z 0-9 space / - ? : ( ) . , ' +`

A trainer named "Müller" or "Schröße", or a course like "Kräftigungsübungen",
causes the generated pain.001.001.09 file to contain characters outside this
set. German banks (and most other European banks) reject or silently mangle
such files. Because German trainer names frequently contain umlauts, this
breaks real payment files in the common case.

## Fix

Add a self-contained `sanitizeSepa` helper in `lib/sepa-charset.ts` with no
new dependencies. It:

- Transliterates German umlauts using the standard ae/oe/ue convention
  (ä -> ae, ö -> oe, ü -> ue, Ä -> Ae, Ö -> Oe, Ü -> Ue, ß -> ss)
- Maps other accented Latin letters (e.g. é -> e, ç -> c) to their base letter
- Silently drops any remaining out-of-charset characters
- Collapses multiple spaces and trims

Apply it to `tx.creditorName` (trainer name), `info.debtorName`, and
`tx.remittanceInfo` before handing to sepa.js.

## Tests

`lib/sepa-generation.test.ts` is extended with:

- Five unit tests for `sanitizeSepa` directly (umlauts, uppercase umlauts,
  pass-through of valid chars, drop of unmapped chars, space collapsing)
- One integration test: a compensation with trainer name "Jörg Müller-Schröße"
  and course "Kräftigungsübungen" is run through `generateSepaXml`; the test
  asserts the `<Nm>` and `<Ustrd>` elements in the generated XML contain only
  EPC217-08 characters and match the expected transliterated strings exactly.

All 9 tests in the file pass.

## Checklist

- [x] No new npm dependencies
- [x] Existing tests unmodified and still pass
- [x] New tests cover the bug scenario directly
- [x] `sanitizeSepa` is self-contained and easy to audit
